### PR TITLE
Replace Apache license with Sonatype Integration Terms EULA - INT-10580 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
-@sonatype-nexus-community/community-leaders
-@guillermo-varela
-@shaikhu
+# Each line is a file pattern followed by one or more owners. More info about CODEOWNERS visit:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# @sonatype/team-atlas will be automatically requested for review when someone opens a pull request.
+* @sonatype/team-atlas

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,5 @@
-(brief, plain english overview of your changes here)
+## Description
 
-This pull request makes the following changes:
-* (your change here)
-* (another change here)
-* (etc)
-
-(If there are changes to user behavior in general, please make sure to
-update the docs, as well)
-
-It relates to the following issue #s:
-* Fixes #X
-
-cc @bhamail / @DarthHater / @guillermo-varela / @shaikhu
+## Links
+JIRA:
+Build: 

--- a/.github/workflows/interaction.yml
+++ b/.github/workflows/interaction.yml
@@ -51,7 +51,7 @@ jobs:
 
             Thank you for opening this pull-request. We appreciate all submissions that helps us continue improving this plugin.
 
-            Please take a look at our [contributing guidelines](https://github.com/sonatype-nexus-community/scan-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and make sure all requirements are fulfilled.
+            Please take a look at our [contributing guidelines](https://github.com/sonatype/scan-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and make sure all requirements are fulfilled.
 
             For Sonatype customers: in addition to opening this pull-request, you can also request support at https://support.sonatype.com
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 
 .env
 .secrets
+/.junie/

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,50 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2024-present Sonatype, Inc.
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+SONATYPE INTEGRATION TERMS EULA
+===============================
 
-   1. Definitions.
+If you do not accept and agree to the following license terms (the “Agreement”), do not access, download or use the
+integration software (the “Integration”).
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+Subject to the terms of this license, Sonatype grants to you a non-transferable, non-assignable, non-sublicensable,
+non-exclusive, limited license to use the Integration solely in conjunction with Sonatype products for which you have
+a valid license (the “Products”) for your internal business purposes only, provided that you preserve all copyright
+and other proprietary notices and include a copy of this license with every copy of the Integration. Sonatype hereby
+reserves the right to revoke the license granted herein and to terminate this license at any time, at its sole and
+absolute discretion, upon written notice to you.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+Subject to the limited rights expressly granted herein, Sonatype, for itself and on behalf of its licensors, reserves
+all rights in the Integration (including all improvements, modifications, derivative works and innovations thereto)
+that are not expressly granted to you herein, and you acknowledge and agree that, except as otherwise expressly set
+forth herein, Sonatype owns all rights, title and interest in and to the Integration.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+This Agreement does not replace, amend or in any way modify the terms and conditions governing your use of and access
+to the Product(s) to which this Integration connects (the ‘EULA”), and the terms of the EULA will continue to govern
+your access to and use of the Products. By using the Integration to establish a connection between the Product(s) and
+the third-party software to which the Integration establishes  a connection (the “Third Party Offering”) you hereby
+represent, warrant, and covenant that (a) you have a valid license to use the Third Party Offering, and (b) that you
+remain fully responsible for ensuring that any Sonatype data transmitted to the Third Party Offering will only be
+used for your internal business purposes in accordance with the terms of the EULA and for no other purpose.
+Furthermore, you shall comply with all export and sanctions laws and regulations of the United States and other
+applicable jurisdictions when performing your obligations and/or exercising your rights hereunder. You represent and
+warrant that neither you nor any of your officers or directors are identified on any U.S. government list of persons
+or entities prohibited from receiving exports or otherwise subject to sanctions and no such sanctioned party has an
+interest in you.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+The Integration is provided “AS IS” WITHOUT WARRANTY OF ANY KIND. SONATYPE MAKES NO, AND HEREBY DISCLAIMS ANY AND ALL,
+REPRESENTATIONS OR WARRANTIES REGARDING THE INTEGRATION, INCLUDING ANY EXPRESS OR IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. SONATYPE DOES NOT WARRANT THAT THE OPERATION
+OF THE INTEGRATION WILL BE ERROR-FREE OR UNINTERRUPTED.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+IN NO EVENT WILL SONATYPE OR ITS LICENSORS BE LIABLE (WHETHER IN CONTRACT, WARRANTY, TORT (INCLUDING NEGLIGENCE),
+PRODUCT LIABILITY OR OTHER THEORY), TO YOU OR ANY OTHER PERSON OR ENTITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES (INCLUDING DAMAGES FOR LOSS OF PROFIT, BUSINESS OR DATA) IN
+EXCESS OF $1,000.00, IN AGGREGATE, ARISING OUT OF YOUR USE OF THE INTEGRATION, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+The validity, construction and performance of this Agreement shall be governed by and construed in accordance with
+the laws of the State of Maryland, without regard to any conflicts of laws or choice of law rules, and each Party
+agrees to submit to the exclusive jurisdiction of the State and Federal courts located in the State of Maryland.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Includes the third-party code listed at http://links.sonatype.com/products/clm/attributions.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 -->
 
 <p align="center">
-    <img src="https://github.com/sonatype-nexus-community/scan-gradle-plugin/blob/main/docs/images/sherlocktrunks.png" width="350"/>
+    <img src="https://github.com/sonatype/scan-gradle-plugin/blob/main/docs/images/sherlocktrunks.png" width="350"/>
 </p>
 
 # Sonatype Scan Gradle Plugin - AKA Sherlock Trunks #
@@ -25,7 +25,7 @@
 
 [![Gradle Plugins Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/org/sonatype/gradle/plugins/scan/org.sonatype.gradle.plugins.scan.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=Gradle%20Plugins%20Portal)](https://plugins.gradle.org/plugin/org.sonatype.gradle.plugins.scan)
 
-![GitHub Actions CI](https://github.com/sonatype-nexus-community/scan-gradle-plugin/actions/workflows/ci.yaml/badge.svg)
+![GitHub Actions CI](https://github.com/sonatype/scan-gradle-plugin/actions/workflows/ci.yaml/badge.svg)
 
 Gradle plugin that scans the dependencies of a Gradle project using Sonatype platforms: Guide (through OSS Index compatibility) and Nexus IQ Server.
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply from: 'gradle/integration-test.gradle'
 
 // Plugin publishing configuration
 def pluginDescription = 'Scan, evaluate and audit Gradle projects using Sonatype platforms'
-def pluginUrl = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin'
+def pluginUrl = 'https://github.com/sonatype/scan-gradle-plugin'
 
 gradlePlugin {
   plugins {
@@ -125,26 +125,26 @@ publishing {
       pom {
         name = project.name
         description = pluginDescription
-        url = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin'
+        url = 'https://github.com/sonatype/scan-gradle-plugin'
         organization {
           name = 'Sonatype'
           url = 'https://www.sonatype.com'
         }
         issueManagement {
           system = 'GitHub'
-          url = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin/issues'
+          url = 'https://github.com/sonatype/scan-gradle-plugin/issues'
         }
         licenses {
           license {
-            name = 'The Apache Software License, Version 2.0'
-            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            name = 'Sonatype-Integration-Terms-EULA'
+            url = 'https://www.sonatype.com/dnt/usage/integration-api-eula'
             distribution = 'repo'
           }
         }
         scm {
-          connection = 'scm:git:git://github.com/sonatype-nexus-community/scan-gradle-plugin.git'
-          developerConnection = 'scm:git:ssh://git@github.com:sonatype-nexus-community/scan-gradle-plugin.git'
-          url = 'https://github.com/sonatype-nexus-community/scan-gradle-plugin'
+          connection = 'scm:git:git://github.com/sonatype/scan-gradle-plugin.git'
+          developerConnection = 'scm:git:ssh://git@github.com:sonatype/scan-gradle-plugin.git'
+          url = 'https://github.com/sonatype/scan-gradle-plugin'
         }
         developers {
           developer {


### PR DESCRIPTION
### Description
- Update repository references and replace Apache license with Sonatype Integration Terms EULA.

### Links
Jira: https://sonatype.atlassian.net/browse/INT-10580
