### PR TITLE
Fix policy violations - upgrade vulnerable dependencies - INT-10746

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,9 @@ dependencies {
     implementation('org.apache.logging.log4j:log4j-api:2.26.1') {
       because('Temporarily pinning version to avoid sonatype-2026-006746')
     }
+    implementation('com.github.luben:zstd-jni:1.5.7-16') {
+      because('Pinning version to avoid CVE-2026-87795 and CVE-2026-87823 (transitive via insight-scanner-archive)')
+    }
   }
 
   testImplementation gradleTestKit()


### PR DESCRIPTION
## Summary

Fixes policy violations from IQ Server scan `bd76f9750eda4967be361a9e7ccbe7aa` for application `scan-gradle-plugin`.

### Components Updated

| Component | Old → New | Type | Strategy | Violations Resolved | Result |
|---|---|---|---|---|---|
| `com.github.luben:zstd-jni` | 1.5.7-4 → 1.5.7-16 | transitive | gradle-constraint | 2 (TL 9, TL 9) | ✅ committed |

`zstd-jni` is a transitive dependency (`insight-scanner-archive` → `insight-scanner-container-image` → `zstd-jni`). No direct-dependency upgrade path exists yet: `insight-scanner-archive` is a private Sonatype internal artifact, and even its unreleased HEAD (3.0.66-SNAPSHOT) still pins `zstd-jni` at 1.5.7-4. Pinned the safe transitive version via the existing "Transitive dependency pinning" `constraints` block in `build.gradle` as a stopgap until `insight-scanner` bumps its own pin.

Resolved:
- Security-High (threat level 9): CVE-2026-87795 (severity 8.2)
- Security-High (threat level 9): CVE-2026-87823 (severity 8.8)

## Related Issue

[INT-10746](https://sonatype.atlassian.net/browse/INT-10746)

## Testing

- [x] Build passes (`./gradlew build` — unit tests, license check, it1-it4 integration tests all green)
- [ ] Re-scan in IQ Server confirms violations cleared

[INT-10746]: https://sonatype.atlassian.net/browse/INT-10746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ